### PR TITLE
Add gradio interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Party Planner Agent Prototype
+
+This project demonstrates a simple interaction with an Ollama language model.
+
+## Running the demo
+
+Install the dependencies and launch the Gradio interface:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+This will start a local web server where you can enter a prompt and see the
+model's response in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,20 @@
+import gradio as gr
+from langchain_ollama import OllamaLLM
+
+# Initialize the language model using the same model as tests/hello_world.py
+llm = OllamaLLM(model="llama3.2")
+
+def generate_response(prompt: str) -> str:
+    """Return a completion from the Ollama model."""
+    return llm.invoke(prompt)
+
+# Basic Gradio interface with a text box for the prompt
+interface = gr.Interface(
+    fn=generate_response,
+    inputs=gr.Textbox(lines=2, placeholder="Enter your prompt here"),
+    outputs="text",
+    title="Party Planner Chat",
+)
+
+if __name__ == "__main__":
+    interface.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ langchain>=0.1.13
 langchain-community>=0.0.24
 langchain-ollama>=0.1.0
 ollama>=0.1.5
+gradio>=5.34.2


### PR DESCRIPTION
## Summary
- create a simple Gradio app to call Ollama
- document running the demo
- add gradio to requirements

## Testing
- `pip install gradio==5.34.2`
- `python app.py & sleep 5; pkill -f app.py` *(fails: connection blocked)*
- `python tests/hello_world.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6854f33eb3088325b7e171f1254abba8