### PR TITLE
Add event detail fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,14 +4,26 @@ from langchain_ollama import OllamaLLM
 # Initialize the language model using the same model as tests/hello_world.py
 llm = OllamaLLM(model="llama3.2")
 
-def generate_response(prompt: str) -> str:
-    """Return a completion from the Ollama model."""
-    return llm.invoke(prompt)
+def generate_response(
+    title: str, date: str, time: str, description: str, prompt: str
+) -> str:
+    """Return a completion from the Ollama model using event context."""
+    full_prompt = (
+        f"Event Title: {title}\nDate: {date}\nTime: {time}\n"
+        f"Description: {description}\n\nUser Prompt: {prompt}"
+    )
+    return llm.invoke(full_prompt)
 
 # Basic Gradio interface with a text box for the prompt
 interface = gr.Interface(
     fn=generate_response,
-    inputs=gr.Textbox(lines=2, placeholder="Enter your prompt here"),
+    inputs=[
+        gr.Textbox(label="Event Title"),
+        gr.components.DateTime(label="Date", include_time=False),
+        gr.components.DateTime(label="Time"),
+        gr.Textbox(label="Description", lines=2),
+        gr.Textbox(lines=2, placeholder="Enter your prompt here", label="Prompt"),
+    ],
     outputs="text",
     title="Party Planner Chat",
 )


### PR DESCRIPTION
## Summary
- collect event title, date, time, and description
- build prompt with event info for Ollama

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854f6191c7c832582bda79ef7c03289