### PR TITLE
Enhance address input fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,27 +1,64 @@
+from dataclasses import dataclass
+
 import gradio as gr
 from langchain_ollama import OllamaLLM
 
 # Initialize the language model using the same model as tests/hello_world.py
 llm = OllamaLLM(model="llama3.2")
 
+
+@dataclass
+class Address:
+    """Simple container for address components."""
+
+    street: str
+    city: str
+    state: str
+    zip_code: str
+    country: str
+
+    def __str__(self) -> str:
+        return (
+            f"{self.street}, {self.city}, {self.state} {self.zip_code}, {self.country}"
+        )
+
+
 def generate_response(
-    title: str, date: str, time: str, description: str, prompt: str
+    title: str,
+    date_time: str,
+    street: str,
+    city: str,
+    state: str,
+    zip_code: str,
+    country: str,
+    description: str,
+    prompt: str,
 ) -> str:
     """Return a completion from the Ollama model using event context."""
+
+    address = Address(
+        street=street, city=city, state=state, zip_code=zip_code, country=country
+    )
     full_prompt = (
-        f"Event Title: {title}\nDate: {date}\nTime: {time}\n"
+        f"Event Title: {title}\nDate: {date_time}\nLocation: {address}\n"
         f"Description: {description}\n\nUser Prompt: {prompt}"
     )
     return llm.invoke(full_prompt)
+
 
 # Basic Gradio interface with a text box for the prompt
 interface = gr.Interface(
     fn=generate_response,
     inputs=[
         gr.Textbox(label="Event Title"),
-        gr.components.DateTime(label="Date"),
-        gr.Textbox(label="Location"),
+        gr.components.DateTime(label="Date & Time"),
+        gr.Textbox(label="Street Address"),
+        gr.Textbox(label="City"),
+        gr.Textbox(label="State"),
+        gr.Textbox(label="ZIP Code"),
+        gr.Textbox(label="Country"),
         gr.Textbox(label="Description", lines=4),
+        gr.Textbox(label="Prompt"),
     ],
     outputs="text",
     title="Party Planner Chat",


### PR DESCRIPTION
## Summary
- split address into multiple components in the Gradio interface
- capture address parts using a dataclass and format them for prompts

## Testing
- `black . --check`


------
https://chatgpt.com/codex/tasks/task_e_6854fc57805083258924a769bdc32d55